### PR TITLE
fix: support for linux arm64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -61,6 +61,7 @@ get_platform() {
 get_arch() {
   local arch=$(uname -m)
   [ "$arch" = "x86_64" ] && arch="amd64"
+  [ "$arch" = "aarch64" ] && arch="arm64"
   echo "$arch"
 }
 


### PR DESCRIPTION
Linux `uname -m` reports `arm64` as `aarch64`